### PR TITLE
Allow to mount a custom share-config-custom.xml

### DIFF
--- a/4.2/skeleton/local/share-config-custom.xml
+++ b/4.2/skeleton/local/share-config-custom.xml
@@ -187,7 +187,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -334,7 +334,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -343,7 +343,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -352,7 +352,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>

--- a/5.0/skeleton/local/share-config-custom.xml
+++ b/5.0/skeleton/local/share-config-custom.xml
@@ -186,7 +186,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -333,7 +333,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -342,7 +342,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -351,7 +351,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -363,7 +363,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/5.1/skeleton/local/share-config-custom.xml
+++ b/5.1/skeleton/local/share-config-custom.xml
@@ -187,7 +187,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -334,7 +334,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -343,7 +343,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -352,7 +352,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>

--- a/5.2/skeleton/local/share-config-custom.xml
+++ b/5.2/skeleton/local/share-config-custom.xml
@@ -210,7 +210,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -357,7 +357,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -366,7 +366,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -375,7 +375,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -387,7 +387,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/6.0/skeleton/local/share-config-custom.xml
+++ b/6.0/skeleton/local/share-config-custom.xml
@@ -210,7 +210,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -357,7 +357,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -366,7 +366,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -375,7 +375,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -387,7 +387,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/6.1/skeleton/local/share-config-custom.xml
+++ b/6.1/skeleton/local/share-config-custom.xml
@@ -212,7 +212,7 @@
          If set, will present a WebDAV link for the current item on the Document and Folder details pages.
          Also used to generate the "View in Alfresco Explorer" action for folders.
       -->
-      <repository-url>http://localhost:8080/alfresco</repository-url>
+      <repository-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}</repository-url>
 
       <!--
          Google Docs™ integration
@@ -359,7 +359,7 @@
             <name>Alfresco - unauthenticated access</name>
             <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>none</identity>
          </endpoint>
 
@@ -368,7 +368,7 @@
             <name>Alfresco - user access</name>
             <description>Access to Alfresco Repository WebScripts that require user authentication</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <identity>user</identity>
          </endpoint>
 
@@ -377,7 +377,7 @@
             <name>Alfresco Feed</name>
             <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
             <connector-id>http</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/s</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/s</endpoint-url>
             <basic-auth>true</basic-auth>
             <identity>user</identity>
          </endpoint>
@@ -389,7 +389,7 @@
             <description>Access to Alfresco Repository Public API that require user authentication.
                          This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
             <connector-id>alfresco</connector-id>
-            <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+            <endpoint-url>${ALFRESCO_PROTOCOL}://${ALFRESCO_HOST}:${ALFRESCO_PORT}/${ALFRESCO_CONTEXT}/api</endpoint-url>
             <identity>user</identity>
          </endpoint>
       </remote>

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,4 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+	
+* [DOCKER-254] Allow to mount a custom share-config-custom.xml. Location to mount: /docker-config/share-config-custom.xml.
+	
 ## [v1.0.0] Make it public

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Environment variables:
 | JMX_RMI_HOST                |                                 |                                                              |  0.0.0.0                                                            |  |
 | JAVA_OPTS_\<variable\>=\<value\>       |                      | \<value\>                                                   |                                                              |  |
 
+If environment variables are not sufficient to cover the use-case desired, a custom share-config-custom.xml file can be mounted in /docker-config/share-config-custom.xml.
+
 ## Docker-compose files
 
 For example docker-compose files, see [docker-alfresco](https://github.com/xenit-eu/docker-alfresco).

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -20,20 +20,20 @@ RUN	mkdir -p /opt/alfresco && \
 	rm -rf ${CATALINA_HOME}/webapps/* && \
 	mkdir -p ${CATALINA_HOME}/bin && \
 	touch ${CATALINA_HOME}/bin/setenv.sh && \
- 	mkdir -p ${CATALINA_HOME}/shared/classes/alfresco/web-extension/
-ADD 	share-config-custom.xml ${CATALINA_HOME}/shared/classes/alfresco/web-extension/
+	mkdir -p ${CATALINA_HOME}/shared/classes/alfresco/web-extension/ && \
+	mkdir -p /docker-config/
+ADD	 share-config-custom.xml /docker-config/
 
 # copy init file
 RUN	mkdir -p /docker-entrypoint.d
-COPY 	91-init-share.sh /docker-entrypoint.d/
+COPY	 91-init-share.sh /docker-entrypoint.d/
 RUN	chmod u+x /docker-entrypoint.d/91-init-share.sh && \
-	
-# permissions
- 	chown -hR tomcat /opt/alfresco && \
-	chown -hR tomcat ${CATALINA_HOME} 
+	# permissions
+	chown -hR tomcat /opt/alfresco && \
+	chown -hR tomcat ${CATALINA_HOME}
 
 # named volumes
-VOLUME 	${CATALINA_HOME}/temp ${CATALINA_HOME}/logs
+VOLUME	 ${CATALINA_HOME}/temp ${CATALINA_HOME}/logs
 
 WORKDIR /opt/alfresco
 

--- a/src/main/resources/dockerfiles/Dockerfile-skeleton
+++ b/src/main/resources/dockerfiles/Dockerfile-skeleton
@@ -16,7 +16,7 @@ USER	root
 
 RUN	mkdir -p /opt/alfresco && \
 	apt-get update && \
-	apt-get install -y curl vim locate jq less && \
+	apt-get install -y curl vim locate jq less gettext-base && \
 	rm -rf ${CATALINA_HOME}/webapps/* && \
 	mkdir -p ${CATALINA_HOME}/bin && \
 	touch ${CATALINA_HOME}/bin/setenv.sh && \

--- a/src/main/resources/global/91-init-share.sh
+++ b/src/main/resources/global/91-init-share.sh
@@ -17,7 +17,12 @@ ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
 ALFRESCO_PROTOCOL=${ALFRESCO_PROTOCOL:-http}
 ALFRESCO_CONTEXT=${ALFRESCO_CONTEXT:-alfresco}
 
-sed -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' </docker-config/share-config-custom.xml >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
+export ALFRESCO_HOST
+export ALFRESCO_PORT
+export ALFRESCO_PROTOCOL
+export ALFRESCO_CONTEXT
+
+envsubst </docker-config/share-config-custom.xml >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
 
 setJavaOption "defaults" "-Xms$JAVA_XMS -Xmx$JAVA_XMX -Dfile.encoding=UTF-8"
 

--- a/src/main/resources/global/91-init-share.sh
+++ b/src/main/resources/global/91-init-share.sh
@@ -17,7 +17,9 @@ ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
 ALFRESCO_PROTOCOL=${ALFRESCO_PROTOCOL:-http}
 ALFRESCO_CONTEXT=${ALFRESCO_CONTEXT:-alfresco}
 
-sed -i -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' ${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml
+sed -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' "${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml" >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/my-share-config-custom.xml"
+cat "${CATALINA_HOME}/shared/classes/alfresco/web-extension/my-share-config-custom.xml" >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
+rm "${CATALINA_HOME}/shared/classes/alfresco/web-extension/my-share-config-custom.xml"
 
 setJavaOption "defaults" "-Xms$JAVA_XMS -Xmx$JAVA_XMX -Dfile.encoding=UTF-8"
 
@@ -26,14 +28,11 @@ then
     setJavaOption "debug" "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8000"
 fi
 
-
 if [ $JMX_ENABLED = true ]
 then
     # be sure port 5000 is mapped on the host also on 5000
     setJavaOption "jmx" "-Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.rmi.port=5000 -Dcom.sun.management.jmxremote.port=5000 -Djava.rmi.server.hostname=${JMX_RMI_HOST}"
 fi
-
-setJavaOptions
 
 echo "Share init done"
 

--- a/src/main/resources/global/91-init-share.sh
+++ b/src/main/resources/global/91-init-share.sh
@@ -17,9 +17,7 @@ ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
 ALFRESCO_PROTOCOL=${ALFRESCO_PROTOCOL:-http}
 ALFRESCO_CONTEXT=${ALFRESCO_CONTEXT:-alfresco}
 
-sed -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' "${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml" >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/my-share-config-custom.xml"
-cat "${CATALINA_HOME}/shared/classes/alfresco/web-extension/my-share-config-custom.xml" >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
-rm "${CATALINA_HOME}/shared/classes/alfresco/web-extension/my-share-config-custom.xml"
+sed -e 's/http:\/\/localhost:8080\/alfresco/'"$ALFRESCO_PROTOCOL"':\/\/'"$ALFRESCO_HOST"':'"$ALFRESCO_PORT"'\/'"$ALFRESCO_CONTEXT"'/g' </docker-config/share-config-custom.xml >"${CATALINA_HOME}/shared/classes/alfresco/web-extension/share-config-custom.xml"
 
 setJavaOption "defaults" "-Xms$JAVA_XMS -Xmx$JAVA_XMX -Dfile.encoding=UTF-8"
 


### PR DESCRIPTION
Do not use "sed -i", because that changes the inode of the file => share-config-custom.xml cannot be mounted.

Writing a new file and dumping its content later into the original is ok.