### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ before_install:
   - mkdir -p $HOME/.gradle
   - touch $HOME/.gradle/gradle.properties
 
+env:
+  matrix:
+    - VERSIONS_TO_BUILD=4
+    - VERSIONS_TO_BUILD=5
+    - VERSIONS_TO_BUILD=6
+
 install:
   - "echo 'buildDate='$(date +%s) >> ~/.gradle/gradle.properties"
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ subprojects {
         // This private repository provides Xenit with Alfresco enterprise artefacts.        
         // External developers should replace it with their own library repository.
         if(project.hasProperty('eu.xenit.artifactory.username') && project.hasProperty('eu.xenit.artifactory.password')) {
-	  maven {
-            name 'Xenit artifactory release local'
-            url 'https://artifactory.xenit.eu/artifactory/libs-release'
-            credentials {
-                username property("eu.xenit.artifactory.username")
-                password property("eu.xenit.artifactory.password")
+            maven {
+                name 'Xenit artifactory release local'
+                url 'https://artifactory.xenit.eu/artifactory/libs-release'
+                credentials {
+                    username property("eu.xenit.artifactory.username")
+                    password property("eu.xenit.artifactory.password")
+                }
             }
-          }
-	}
+        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,12 +33,23 @@ def includeSubprojectPerVersion(major,flavor) {
 
 rootProject.name = 'docker-share'
 
-includeSubprojectPerVersion("4.","community")
-includeSubprojectPerVersion("5.","community")
-includeSubprojectPerVersion("6.","community")
-if(hasProperty("enterprise")) {
-    includeSubprojectPerVersion("4.","enterprise")
-    includeSubprojectPerVersion("5.","enterprise")
-    includeSubprojectPerVersion("6.","enterprise")
+if(System.getenv("VERSIONS_TO_BUILD")==null || System.getenv("VERSIONS_TO_BUILD").equals("4")) {
+    includeSubprojectPerVersion("4.","community")
+    if(hasProperty("enterprise")) {
+        includeSubprojectPerVersion("4.","enterprise")
+    }
 }
 
+if(System.getenv("VERSIONS_TO_BUILD")==null || System.getenv("VERSIONS_TO_BUILD").equals("5")) {
+    includeSubprojectPerVersion("5.","community")
+    if(hasProperty("enterprise")) {
+        includeSubprojectPerVersion("5.","enterprise")
+    }
+}
+
+if(System.getenv("VERSIONS_TO_BUILD")==null || System.getenv("VERSIONS_TO_BUILD").equals("6")) {
+    includeSubprojectPerVersion("6.","community")
+    if(hasProperty("enterprise")) {
+        includeSubprojectPerVersion("6.","enterprise")
+    }
+}


### PR DESCRIPTION
Hello @vierbergenlars ,

With the updates on docker-openjdk and docker-tomcat, I think it is a good idea to rebuild the docker-share images so they contain the last openjdk and tomcat updates.

However the Alfresco Share community builds on Travis-CI don't build successfully due to the following error:
`The job exceeded the maximum log length, and has been terminated.`

I don't know if the changes made now are sufficient to split the build over multiple Travis-CI build agents. (Apparently it is enough - see Travis CI - Branch and Pull Request builds)
I could be possible additional changes have to be made to reduce build logging. (Seems not to be needed for now  - see Travis CI - Branch and Pull Request builds)

Kind regards,
Koen