### PR TITLE
Set flag to skip cleanup of the repository on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script: travis_wait 60 ./gradlew -PrepoName=docker.io/xenit buildDockerImage --i
 deploy:
   provider: script
   script: ./gradlew --stacktrace -PrepoName=docker.io/xenit pushDockerImage
+  skip_cleanup: true
   cleanup: false
   on:
     branch: master


### PR DESCRIPTION
See https://docs.travis-ci.com/user/deployment/\#uploading-files-and-skip_cleanup
Doing full git stash, which results in a lot of output on travis, and results in a fatal error

We should not be cleaning up the repository before performing the deployment, as it is best that the Gradle caches
can be reused to speed up the deployment step.
The previously configured  is only valid for dpl v2, which is not yet used by default on travis.