### PR TITLE
DOCKER-395: Add Share 7.0.1.1 image

### DIFF
--- a/2share/7.0/community-7.0.1/overload.gradle
+++ b/2share/7.0/community-7.0.1/overload.gradle
@@ -4,13 +4,13 @@ ext {
                     major: 7,
                     minor: 0,
                     rev: 1,
-                    label: 2
+                    label: 1
             ],
             flavor: 'community'
     ]
 }
 
 dependencies {
-    baseShareWar 'org.alfresco:share:7.0.1.2@war'
+    baseShareWar 'org.alfresco:share:7.0.1.1@war'
 }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [DOCKER-275] Introduce variables for direct communication share-alfresco. Make sure that ALFRESCO_INTERNAL_HOST is set to the correct name of the alfresco service/container.
 * [DEVEM-478] Share 7.0.0
 * [DOCKER-392] Share 7.0.1.2
+* [DOCKER-395] Share 7.0.1.1
 
 ### Changed
 


### PR DESCRIPTION
Contrary to what I presumed in #21, https://artifacts.alfresco.com/nexus/service/local/repositories/enterprise-releases/content/org/alfresco/acs-packaging/7.0.1.3/acs-packaging-7.0.1.3.pom (idem for 7.0.1.5, the newest release atm) species share-services 7.0.1.1. If not set to this version exactly, a warning is given in Share.